### PR TITLE
Update to Minecraft 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,9 +13,9 @@ val groupString = project.property("group") as String
 
 
 plugins {
-    kotlin("jvm") version "2.2.21"
-    kotlin("plugin.serialization") version "2.2.21"
-    id("fabric-loom") version "1.13-SNAPSHOT"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.serialization") version "2.3.21"
+    id("net.fabricmc.fabric-loom") version "1.14-SNAPSHOT"
     id("com.modrinth.minotaur") version "2.8.7"
     id("com.matthewprenger.cursegradle") version "1.4.0"
 }
@@ -30,21 +30,21 @@ repositories {
 
 dependencies {
     minecraft("com.mojang:minecraft:$minecraftVersion")
-    mappings(loom.officialMojangMappings())
-    modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
-    modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricAPIVersion")
-    modImplementation("net.fabricmc:fabric-language-kotlin:$kotlinVersion")
-    modApi("com.terraformersmc:modmenu:$modmenuVersion")
+    // No mappings needed for MC 26.1+ (unobfuscated)
+    implementation("net.fabricmc:fabric-loader:$loaderVersion")
+    implementation("net.fabricmc.fabric-api:fabric-api:$fabricAPIVersion")
+    implementation("net.fabricmc:fabric-language-kotlin:$kotlinVersion")
+    api("com.terraformersmc:modmenu:$modmenuVersion")
 }
 
 tasks {
     compileJava {
         options.encoding = "UTF-8"
-        options.release.set(21)
+        options.release.set(25)
     }
     compileKotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
         }
     }
     processResources {
@@ -63,7 +63,7 @@ modrinth {
     projectId.set("perspektive")
     versionNumber.set(rootProject.version.toString())
     versionType.set("release")
-    uploadFile.set(tasks.remapJar.get())
+    uploadFile.set(tasks.named("jar").get())
     gameVersions.set(listOf(minecraftVersion))
     loaders.addAll(listOf("fabric", "quilt"))
 
@@ -79,7 +79,7 @@ modrinth {
 curseforge {
     apiKey = findProperty("curseforge.token") ?: ""
     project(closureOf<com.matthewprenger.cursegradle.CurseProject> {
-        mainArtifact(tasks.getByName("remapJar").outputs.files.first())
+        mainArtifact(tasks.getByName("jar").outputs.files.first())
 
         id = "501553"
         releaseType = "release"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ val groupString = project.property("group") as String
 plugins {
     kotlin("jvm") version "2.3.21"
     kotlin("plugin.serialization") version "2.3.21"
-    id("net.fabricmc.fabric-loom") version "1.14-SNAPSHOT"
+    id("net.fabricmc.fabric-loom") version "1.15-SNAPSHOT"
     id("com.modrinth.minotaur") version "2.8.7"
     id("com.matthewprenger.cursegradle") version "1.4.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 
 group = de.royzer
-mod_version=1.4.4
-minecraft_version=1.21.11
-loader_version=0.18.1
-loom_version=1.13-SNAPSHOT
+mod_version=1.4.5
+minecraft_version=26.1.2
+loader_version=0.19.2
+loom_version=1.14-SNAPSHOT
 
 
 # Fabric API
-fabric_version=0.141.2+1.21.11
-fabric_language_kotlin_version=1.13.7+kotlin.2.2.21
-modmenu_version=16.0.0-rc.1
+fabric_version=0.147.0+26.1.2
+fabric_language_kotlin_version=1.13.11+kotlin.2.3.21
+modmenu_version=18.0.0-alpha.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ group = de.royzer
 mod_version=1.4.5
 minecraft_version=26.1.2
 loader_version=0.19.2
-loom_version=1.14-SNAPSHOT
+loom_version=1.15-SNAPSHOT
 
 
 # Fabric API

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/royzer/perspektive/mixins/CameraMixin.java
+++ b/src/main/java/de/royzer/perspektive/mixins/CameraMixin.java
@@ -21,6 +21,9 @@ public abstract class CameraMixin {
     @Shadow
     protected abstract void move(float x, float y, float z);
 
+    @Shadow
+    private float getMaxZoom(float desiredDistance) { throw new AssertionError(); }
+
     /**
      * Inject inside alignWithEntity, right before the third-person move() call.
      * This overrides the camera rotation to the freelook rotation so that
@@ -47,7 +50,9 @@ public abstract class CameraMixin {
         if (Perspektive.INSTANCE.getFreeLookEnabled() ||
                 (PerspektiveSettings.INSTANCE.getCameraDistanceAlsoIn3rdPerson()
                         && Minecraft.getInstance().options.getCameraType() != CameraType.FIRST_PERSON)) {
-            this.move(-((float)PerspektiveSettings.INSTANCE.getCameraDistance()), 0.0F, 0.0F);
+            float desiredDistance = (float) PerspektiveSettings.INSTANCE.getCameraDistance();
+            float clampedDistance = this.getMaxZoom(desiredDistance);
+            this.move(-clampedDistance, 0.0F, 0.0F);
         }
     }
 }

--- a/src/main/java/de/royzer/perspektive/mixins/CameraMixin.java
+++ b/src/main/java/de/royzer/perspektive/mixins/CameraMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.CameraType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,7 +14,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Camera.class)
 public abstract class CameraMixin {
-    private boolean firstPress = true;
 
     @Shadow
     protected abstract void setRotation(float yaw, float pitch);
@@ -23,43 +21,33 @@ public abstract class CameraMixin {
     @Shadow
     protected abstract void move(float x, float y, float z);
 
-    @Shadow
-    protected abstract float getMaxZoom(float desiredCameraDistance);
-
-    @Shadow
-    private Entity entity;
-
+    /**
+     * Inject inside alignWithEntity, right before the third-person move() call.
+     * This overrides the camera rotation to the freelook rotation so that
+     * the subsequent move() offsets the camera in the correct direction.
+     */
     @Inject(
-            method = "setup",
+            method = "alignWithEntity",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/Camera;setRotation(FF)V",
-                    shift = At.Shift.AFTER,
-                    ordinal = 1
+                    target = "Lnet/minecraft/client/Camera;getMaxZoom(F)F"
             )
     )
-    public void update(Level level, Entity focusedEntity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci) {
+    public void onAlignWithEntity(float partialTicks, CallbackInfo ci) {
         if (Perspektive.INSTANCE.getFreeLookEnabled()) {
-            if (firstPress) {
-                Perspektive.setPitch(focusedEntity.getXRot());
-                Perspektive.setYaw(focusedEntity.getYRot());
-            }
-            firstPress = false;
             this.setRotation(Perspektive.getYaw(), Perspektive.getPitch());
-        } else {
-            firstPress = true;
         }
     }
 
     @Inject(
-            method = "setup",
+            method = "alignWithEntity",
             at = @At("TAIL")
     )
-    public void setDistance(Level level, Entity focusedEntity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci) {
+    public void setDistance(float partialTicks, CallbackInfo ci) {
         if (Perspektive.INSTANCE.getFreeLookEnabled() ||
                 (PerspektiveSettings.INSTANCE.getCameraDistanceAlsoIn3rdPerson()
                         && Minecraft.getInstance().options.getCameraType() != CameraType.FIRST_PERSON)) {
-            this.move(-this.getMaxZoom((float)PerspektiveSettings.INSTANCE.getCameraDistance()), 0.0F, 0.0F);
+            this.move(-((float)PerspektiveSettings.INSTANCE.getCameraDistance()), 0.0F, 0.0F);
         }
     }
 }

--- a/src/main/kotlin/de/royzer/perspektive/Perspektive.kt
+++ b/src/main/kotlin/de/royzer/perspektive/Perspektive.kt
@@ -4,7 +4,7 @@ import com.mojang.blaze3d.platform.InputConstants
 import de.royzer.perspektive.settings.PerspektiveSettings
 import de.royzer.perspektive.settings.loadConfig
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper
 import net.minecraft.client.CameraType
 import net.minecraft.client.KeyMapping
 import net.minecraft.client.KeyMapping.Category
@@ -28,10 +28,10 @@ object Perspektive {
         Identifier.fromNamespaceAndPath("perspektive", "perspektive")
     )
 
-    private val useKeybind: KeyMapping = KeyBindingHelper.registerKeyBinding(
+    private val useKeybind: KeyMapping = KeyMappingHelper.registerKeyMapping(
         KeyMapping("Freelook", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_Y, modKeybindCategory)
     )
-    private val toggleKeybind: KeyMapping = KeyBindingHelper.registerKeyBinding(
+    private val toggleKeybind: KeyMapping = KeyMappingHelper.registerKeyMapping(
         KeyMapping("Toggle Freelook", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_M, modKeybindCategory)
     )
 
@@ -40,16 +40,29 @@ object Perspektive {
 
         ClientTickEvents.END_CLIENT_TICK.register {
             while (toggleKeybind.consumeClick()) {
+                if (!freeLookToggled) {
+                    perspectiveBefore = Minecraft.getInstance().options.cameraType
+                    // Capture player rotation so camera starts behind the character
+                    Minecraft.getInstance().player?.let {
+                        pitch = it.xRot
+                        yaw = it.yRot
+                    }
+                }
                 freeLookEnabled = true
-                if (!freeLookToggled) perspectiveBefore = Minecraft.getInstance().options.cameraType
                 Minecraft.getInstance().options.cameraType = CameraType.THIRD_PERSON_BACK
                 freeLookToggled = !freeLookToggled
             }
             if (useKeybind.isDown) {
                 if (freeLookToggled) return@register
                 else {
-                    if (!freeLookEnabled)
+                    if (!freeLookEnabled) {
                         perspectiveBefore = Minecraft.getInstance().options.cameraType
+                        // Capture player rotation so camera starts behind the character
+                        Minecraft.getInstance().player?.let {
+                            pitch = it.xRot
+                            yaw = it.yRot
+                        }
+                    }
                     freeLookEnabled = true
                     Minecraft.getInstance().options.cameraType = CameraType.THIRD_PERSON_BACK
                 }

--- a/src/main/kotlin/de/royzer/perspektive/settings/PerspektiveSettingsScreen.kt
+++ b/src/main/kotlin/de/royzer/perspektive/settings/PerspektiveSettingsScreen.kt
@@ -1,7 +1,6 @@
 package de.royzer.perspektive.settings
 
 import de.royzer.perspektive.CameraDistanceOption
-import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.components.Tooltip
 import net.minecraft.client.gui.screens.Screen
@@ -139,7 +138,4 @@ class PerspektiveSettingsScreen(
         this.minecraft?.setScreen(lastScreen)
     }
 
-    override fun extractRenderState(guiGraphics: GuiGraphicsExtractor, i: Int, j: Int, f: Float) {
-        super.extractRenderState(guiGraphics, i, j, f)
-    }
 }

--- a/src/main/kotlin/de/royzer/perspektive/settings/PerspektiveSettingsScreen.kt
+++ b/src/main/kotlin/de/royzer/perspektive/settings/PerspektiveSettingsScreen.kt
@@ -1,7 +1,7 @@
 package de.royzer.perspektive.settings
 
 import de.royzer.perspektive.CameraDistanceOption
-import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.components.Tooltip
 import net.minecraft.client.gui.screens.Screen
@@ -139,14 +139,7 @@ class PerspektiveSettingsScreen(
         this.minecraft?.setScreen(lastScreen)
     }
 
-    override fun render(guiGraphics: GuiGraphics, i: Int, j: Int, f: Float) {
-//        renderBackground(guiGraphics)
-        super.render(guiGraphics, i, j, f)
+    override fun extractRenderState(guiGraphics: GuiGraphicsExtractor, i: Int, j: Int, f: Float) {
+        super.extractRenderState(guiGraphics, i, j, f)
     }
 }
-
-//val cameraDistanceOption = OptionInstance("perspektive.distance", OptionInstance.noTooltip(), { optionText, value ->
-//        Options.genericValueLabel(optionText, Component.literal((value.toString().toDouble() / 10.0).toString()))
-//}, OptionInstance.IntRange(0, 640), (PerspektiveSettings.cameraDistance * 10).toInt()) {
-//    PerspektiveSettings.cameraDistance = it.toString().toDouble() / 10
-//}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "r0yzer"
   ],
   "depends": {
-    "minecraft": ">=1.21.11",
+    "minecraft": ">=26.1.2",
     "fabricloader": ">=0.8.7",
     "fabric-language-kotlin": "*",
     "fabric-api": "*"

--- a/src/main/resources/perspektive.mixins.json
+++ b/src/main/resources/perspektive.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "de.royzer.perspektive.mixins",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "client": [
     "CameraMixin",
     "EntityMixin",

--- a/src/main/resources/perspektive.mixins.json
+++ b/src/main/resources/perspektive.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "de.royzer.perspektive.mixins",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "client": [
     "CameraMixin",
     "EntityMixin",


### PR DESCRIPTION
Updates the mod to work with Minecraft 26.1.2.

> ⚠️ **Disclosure:** This update was written with the assistance of AI (Claude Opus). But the changes have been reviewed and tested in-game by me.

### Changes

**Build system** (MC 26.1 is unobfuscated — no mappings needed):
- Gradle 8.14.1 → 9.5.0 (Java 25 support)
- `fabric-loom` → `net.fabricmc.fabric-loom` (non-remapping loom)
- Removed `mappings(loom.officialMojangMappings())`
- `modImplementation` → `implementation`
- JVM target → 25

**Dependencies:**
- Fabric API: 0.147.0+26.1.2
- Fabric Language Kotlin: 1.13.11+kotlin.2.3.21
- Fabric Loader: 0.19.2
- ModMenu: 18.0.0-alpha.8

**Code changes** (MC 26.1.2 API renames):
- `KeyBindingHelper` → `KeyMappingHelper` (package: `keybinding` → `keymapping`)
- `GuiGraphics` → `GuiGraphicsExtractor`
- `Screen.render()` → `Screen.extractRenderState()`
- `Camera.setup()` → hook inside `Camera.alignWithEntity()` (method was restructured)
- Mixin compatibility level: JAVA_17 → JAVA_21

Tested in-game — freelook and camera distance features work correctly.