### PR TITLE
Update to Minecraft 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 
 group = de.royzer
-mod_version=1.4.5
-minecraft_version=26.1.2
-loader_version=0.19.2
+mod_version=1.4.7
+minecraft_version=26.2
+loader_version=0.19.3
 loom_version=1.15-SNAPSHOT
 
 
 # Fabric API
-fabric_version=0.147.0+26.1.2
-fabric_language_kotlin_version=1.13.11+kotlin.2.3.21
-modmenu_version=18.0.0-alpha.8
+fabric_version=0.153.0+26.2
+fabric_language_kotlin_version=1.13.12+kotlin.2.4.0
+modmenu_version=20.0.0-beta.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/de/royzer/perspektive/settings/PerspektiveSettingsScreen.kt
+++ b/src/main/kotlin/de/royzer/perspektive/settings/PerspektiveSettingsScreen.kt
@@ -19,7 +19,7 @@ class PerspektiveSettingsScreen(
                     .append(if (PerspektiveSettings.shouldReturnToFirstPerson) CommonComponents.OPTION_ON else CommonComponents.OPTION_OFF)
             ) {
                 PerspektiveSettings.shouldReturnToFirstPerson = !PerspektiveSettings.shouldReturnToFirstPerson
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 - 185, this.height / 6 + 4 - 6)
                 .size(250, 20)
@@ -28,7 +28,7 @@ class PerspektiveSettingsScreen(
         addRenderableWidget(
             Button.builder(Component.nullToEmpty("Reset")) {
                 PerspektiveSettings.shouldReturnToFirstPerson = false
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 + 85, this.height / 6 + 4 - 6)
                 .size(100, 20)
@@ -37,7 +37,7 @@ class PerspektiveSettingsScreen(
         // camera distance
         addRenderableWidget(
             CameraDistanceOption.cameraDistanceOption.createButton(
-                this.minecraft!!.options,
+                this.minecraft.options,
                 width / 2 - 185,
                 height / 6 + 28,
                 250
@@ -47,7 +47,7 @@ class PerspektiveSettingsScreen(
             Button.builder(Component.nullToEmpty("Reset")) {
                 PerspektiveSettings.cameraDistance = 0.0
                 CameraDistanceOption.cameraDistanceOption.set(0)
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 + 85, this.height / 6 + 28)
                 .size(100, 20)
@@ -60,7 +60,7 @@ class PerspektiveSettingsScreen(
                     .append(if (PerspektiveSettings.scrollingEnabled) CommonComponents.OPTION_ON else CommonComponents.OPTION_OFF)
             ) {
                 PerspektiveSettings.scrollingEnabled = !PerspektiveSettings.scrollingEnabled
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 - 185, this.height / 6 + 58)
                 .size(250, 20)
@@ -69,7 +69,7 @@ class PerspektiveSettingsScreen(
         addRenderableWidget(
             Button.builder(Component.nullToEmpty("Reset")) {
                 PerspektiveSettings.scrollingEnabled = true
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 + 85, this.height / 6 + 58)
                 .size(100, 20)
@@ -82,7 +82,7 @@ class PerspektiveSettingsScreen(
                     .append(if (PerspektiveSettings.blockInventoryScrolling) CommonComponents.OPTION_ON else CommonComponents.OPTION_OFF)
             ) {
                 PerspektiveSettings.blockInventoryScrolling = !PerspektiveSettings.blockInventoryScrolling
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 - 185, this.height / 6 + 88)
                 .tooltip(Tooltip.create(Component.translatable("perspektive.tooltips.blockScrolling")))
@@ -92,7 +92,7 @@ class PerspektiveSettingsScreen(
         addRenderableWidget(
             Button.builder(Component.nullToEmpty("Reset")) {
                 PerspektiveSettings.blockInventoryScrolling = true
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 + 85, this.height / 6 + 88)
                 .size(100, 20)
@@ -106,7 +106,7 @@ class PerspektiveSettingsScreen(
                     .append(if (PerspektiveSettings.cameraDistanceAlsoIn3rdPerson) CommonComponents.OPTION_ON else CommonComponents.OPTION_OFF)
             ) {
                 PerspektiveSettings.cameraDistanceAlsoIn3rdPerson = !PerspektiveSettings.cameraDistanceAlsoIn3rdPerson
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 - 185, this.height / 6 + 118)
                 .size(250, 20)
@@ -116,7 +116,7 @@ class PerspektiveSettingsScreen(
         addRenderableWidget(
             Button.builder(Component.nullToEmpty("Reset")) {
                 PerspektiveSettings.cameraDistanceAlsoIn3rdPerson = false
-                this.minecraft?.setScreen(this)
+                this.minecraft.setScreenAndShow(this)
             }
                 .pos(this.width / 2 + 85, this.height / 6 + 118)
                 .size(100, 20)
@@ -135,7 +135,7 @@ class PerspektiveSettingsScreen(
 
     override fun onClose() {
         saveConfig()
-        this.minecraft?.setScreen(lastScreen)
+        this.minecraft.setScreenAndShow(lastScreen)
     }
 
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "r0yzer"
   ],
   "depends": {
-    "minecraft": ">=26.1.2",
+    "minecraft": ">=26.2",
     "fabricloader": ">=0.8.7",
     "fabric-language-kotlin": "*",
     "fabric-api": "*"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                        
  Updates the mod to support Minecraft 26.2 and refreshes the toolchain and dependency versions accordingly.                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                                                                                        
  - **Minecraft 26.2 support**                                                                                                                                                                                                                                                                                      
    - Bump `minecraft_version` to `26.2` and update the `minecraft` dependency floor in `fabric.mod.json` to `>=26.2`                                                                                                                                                                                               
    - Bump mod version to `1.4.7`                                                                                                                                                                                                                                                                                   
  - **Dependency updates**                                                                                                                                                                                                                                                                                          
    - Fabric Loader `0.19.2` → `0.19.3`                                                                                                                                                                                                                                                                             
    - Fabric API `0.147.0+26.1.2` → `0.153.0+26.2`                                                                                                                                                                                                                                                                  
    - Fabric Language Kotlin `1.13.11+kotlin.2.3.21` → `1.13.12+kotlin.2.4.0`                                                                                                                                                                                                                                       
    - Mod Menu `18.0.0-alpha.8` → `20.0.0-beta.4`                                                                                                                                                                                                                                                                   
  - **Toolchain**                                                                                                                                                                                                                                                                                                   
    - Gradle wrapper `9.5.0` → `9.6.0`                                                                                                                                                                                                                                                                              
  - **Settings screen API migration**                                                                                                                                                                                                                                                                               
    - Replace the removed/deprecated nullable `minecraft?.setScreen(...)` calls with `minecraft.setScreenAndShow(...)` throughout `PerspektiveSettingsScreen`, and drop the `!!` non-null assertion on `minecraft.options`